### PR TITLE
feat: update Claude model to claude-opus-4-7 with 1M context

### DIFF
--- a/lib/generate-response.ts
+++ b/lib/generate-response.ts
@@ -527,7 +527,7 @@ export const generateResponse = async (
 
     // Call the model
     const { text } = await generateText({
-      model: anthropic("claude-sonnet-4-6"),
+      model: anthropic("claude-opus-4-7"),
       system: systemPrompt,
       messages,
       maxSteps: 30,

--- a/worker/execute-task.ts
+++ b/worker/execute-task.ts
@@ -161,8 +161,8 @@ async function summarizeOutput(
     const client = new Anthropic({ apiKey: workerEnv.ANTHROPIC_API_KEY });
 
     const response = await client.messages.create({
-      model: "claude-sonnet-4-20250514",
-      max_tokens: 1024,
+      model: "claude-opus-4-7",
+      max_tokens: 1000000,
       messages: [
         {
           role: "user",


### PR DESCRIPTION
Switch both the main agent orchestration model and the worker summarization model from claude-sonnet-4-* to claude-opus-4-7. Update max_tokens to 1000000 to leverage the full 1M context window.